### PR TITLE
Remove event binding on Log Action vars

### DIFF
--- a/UnhollowerBaseLib/LogSupport.cs
+++ b/UnhollowerBaseLib/LogSupport.cs
@@ -5,10 +5,10 @@ namespace UnhollowerBaseLib
 {
     public static class LogSupport
     {
-        public static event Action<string> ErrorHandler;
-        public static event Action<string> WarningHandler;
-        public static event Action<string> InfoHandler;
-        public static event Action<string> TraceHandler;
+        public static Action<string> ErrorHandler;
+        public static Action<string> WarningHandler;
+        public static Action<string> InfoHandler;
+        public static Action<string> TraceHandler;
 
         public static void InstallConsoleHandlers()
         {


### PR DESCRIPTION
Removing this binding allows an assembly to remove Action delegates that have already been linked to the event, even if the assembly doesn't have the original delegate signature.
Alternative could be to add a RemoveInstalledHandlers function:
            LogSupport.TraceHandler?.GetInvocationList().ToList().ForEach(d => LogSupport.TraceHandler -= (Action<String>)d);
            LogSupport.ErrorHandler?.GetInvocationList().ToList().ForEach(d => LogSupport.ErrorHandler -= (Action<String>)d);
            LogSupport.InfoHandler?.GetInvocationList().ToList().ForEach(d => LogSupport.InfoHandler -= (Action<String>)d);
            LogSupport.WarningHandler?.GetInvocationList().ToList().ForEach(d => LogSupport.WarningHandler -= (Action<String>)d);