### PR TITLE
Implement changes to help library-level intergration

### DIFF
--- a/AssemblyUnhollower/Contexts/RewriteGlobalContext.cs
+++ b/AssemblyUnhollower/Contexts/RewriteGlobalContext.cs
@@ -84,11 +84,11 @@ namespace AssemblyUnhollower.Contexts
 
         public void Dispose()
         {
-	        foreach (var assembly in Assemblies)
-	        {
-		        assembly.NewAssembly.Dispose();
+            foreach (var assembly in Assemblies)
+            {
+                assembly.NewAssembly.Dispose();
                 assembly.OriginalAssembly.Dispose();
-	        }
+            }
         }
     }
 }

--- a/AssemblyUnhollower/Program.cs
+++ b/AssemblyUnhollower/Program.cs
@@ -23,7 +23,7 @@ namespace AssemblyUnhollower
 
             public void Dispose()
             {
-	            LogSupport.Info($"Done in {myStopwatch.Elapsed}");
+                LogSupport.Info($"Done in {myStopwatch.Elapsed}");
             }
         }
 

--- a/AssemblyUnhollower/Program.cs
+++ b/AssemblyUnhollower/Program.cs
@@ -10,20 +10,20 @@ using UnhollowerRuntimeLib;
 
 namespace AssemblyUnhollower
 {
-    class Program
+    public class Program
     {
         private struct TimingCookie : IDisposable
         {
             private Stopwatch myStopwatch;
             public TimingCookie(string message)
             {
-                Console.Write(message + "... ");
+                LogSupport.Info(message + "... ");
                 myStopwatch = Stopwatch.StartNew();
             }
 
             public void Dispose()
             {
-                Console.WriteLine($"Done in {myStopwatch.Elapsed}");
+	            LogSupport.Info($"Done in {myStopwatch.Elapsed}");
             }
         }
 

--- a/AssemblyUnhollower/Program.cs
+++ b/AssemblyUnhollower/Program.cs
@@ -228,6 +228,8 @@ namespace AssemblyUnhollower
             File.Copy(typeof(Decoder).Assembly.Location, Path.Combine(options.OutputDir, typeof(Decoder).Assembly.GetName().Name + ".dll"), true);
             
             Console.WriteLine("Done!");
+
+            rewriteContext.Dispose();
         }
     }
 }


### PR DESCRIPTION
Also includes object disposal fixes, as lingering file handles cause issues with a process that stays open after performing unhollower tasks