### PR TITLE
Minor QoL fix for Logging Class Injections

### DIFF
--- a/UnhollowerBaseLib/ClassInjector.cs
+++ b/UnhollowerBaseLib/ClassInjector.cs
@@ -66,7 +66,7 @@ namespace UnhollowerRuntimeLib
             *(IntPtr*) targetGcHandlePointer = handleAsPointer;
         }
 
-        public static void RegisterTypeInIl2Cpp<T>() where T : class
+        public static void RegisterTypeInIl2Cpp<T>(bool suppressLogSuccess = false) where T : class
         {
             var type = typeof(T);
             
@@ -153,8 +153,11 @@ namespace UnhollowerRuntimeLib
 
             RuntimeSpecificsStore.SetClassInfo(classPointer.Pointer, true, true);
             Il2CppClassPointerStore<T>.NativeClassPtr = classPointer.Pointer;
-            
-            LogSupport.Info($"Registered mono type {typeof(T)} in il2cpp domain");
+
+            if (!suppressLogSuccess)
+            {
+                LogSupport.Info($"Registered mono type {typeof(T)} in il2cpp domain");
+            }
         }
 
         internal static IntPtr ReadClassPointerForType(Type type)

--- a/UnhollowerBaseLib/ClassInjector.cs
+++ b/UnhollowerBaseLib/ClassInjector.cs
@@ -66,7 +66,8 @@ namespace UnhollowerRuntimeLib
             *(IntPtr*) targetGcHandlePointer = handleAsPointer;
         }
 
-        public static void RegisterTypeInIl2Cpp<T>(bool suppressLogSuccess = false) where T : class
+        public static void RegisterTypeInIl2Cpp<T>() where T : class => RegisterTypeInIl2Cpp<T>(true);
+        public static void RegisterTypeInIl2Cpp<T>(bool logSuccess) where T : class
         {
             var type = typeof(T);
             
@@ -154,10 +155,7 @@ namespace UnhollowerRuntimeLib
             RuntimeSpecificsStore.SetClassInfo(classPointer.Pointer, true, true);
             Il2CppClassPointerStore<T>.NativeClassPtr = classPointer.Pointer;
 
-            if (!suppressLogSuccess)
-            {
-                LogSupport.Info($"Registered mono type {typeof(T)} in il2cpp domain");
-            }
+            if (logSuccess) LogSupport.Info($"Registered mono type {typeof(T)} in il2cpp domain");
         }
 
         internal static IntPtr ReadClassPointerForType(Type type)


### PR DESCRIPTION
#### Reference Issues/PRs

When registering a type with `RegisterTypeInIl2Cpp` in the class `ClassInjector`, a success is followed by a notification in the log. This may be undesirable in some situations, such as when doing many class injections.

#### What does this implement/fix? Explain your changes.

I added a parameter to suppress output in the log after a successful class injection. This parameter is set by default to not suppress any output.

#### Any other comments?

No