### PR TITLE
Added optional parameters to Of and From in Il2CppType

### DIFF
--- a/UnhollowerBaseLib/Il2CppType.cs
+++ b/UnhollowerBaseLib/Il2CppType.cs
@@ -8,15 +8,15 @@ namespace UnhollowerRuntimeLib
         public static Il2CppSystem.Type TypeFromPointer(IntPtr classPointer, string typeName = "<unknown type>") => TypeFromPointerInternal(classPointer, typeName, true);
 
         private static Il2CppSystem.Type TypeFromPointerInternal(IntPtr classPointer, string typeName, bool throwOnFailure)
-		{
+        {
             if (classPointer == IntPtr.Zero)
-			{
+            {
                 if (throwOnFailure) throw new ArgumentException($"{typeName} does not have a corresponding IL2CPP class pointer");
                 else return null;
             }
             var il2CppType = IL2CPP.il2cpp_class_get_type(classPointer);
             if (il2CppType == IntPtr.Zero)
-			{
+            {
                 if (throwOnFailure) throw new ArgumentException($"{typeName} does not have a corresponding IL2CPP type pointer");
                 else return null;
             }

--- a/UnhollowerBaseLib/Il2CppType.cs
+++ b/UnhollowerBaseLib/Il2CppType.cs
@@ -5,24 +5,38 @@ namespace UnhollowerRuntimeLib
 {
     public static class Il2CppType
     {
-        public static Il2CppSystem.Type TypeFromPointer(IntPtr classPointer, string typeName = "<unknown type>")
-        {
-            if (classPointer == IntPtr.Zero) throw new ArgumentException($"{typeName} does not have a corresponding IL2CPP class pointer");
+        public static Il2CppSystem.Type TypeFromPointer(IntPtr classPointer, string typeName = "<unknown type>") => TypeFromPointerInternal(classPointer, typeName, true);
+
+        private static Il2CppSystem.Type TypeFromPointerInternal(IntPtr classPointer, string typeName, bool throwOnFailure)
+		{
+            if (classPointer == IntPtr.Zero)
+			{
+                if (throwOnFailure) throw new ArgumentException($"{typeName} does not have a corresponding IL2CPP class pointer");
+                else return null;
+            }
             var il2CppType = IL2CPP.il2cpp_class_get_type(classPointer);
-            if (il2CppType == IntPtr.Zero) throw new ArgumentException($"{typeName} does not have a corresponding IL2CPP type pointer");
+            if (il2CppType == IntPtr.Zero)
+			{
+                if (throwOnFailure) throw new ArgumentException($"{typeName} does not have a corresponding IL2CPP type pointer");
+                else return null;
+            }
             return Il2CppSystem.Type.internal_from_handle(il2CppType);
         }
 
-        public static Il2CppSystem.Type From(Type type)
+        public static Il2CppSystem.Type From(Type type) => From(type, true);
+
+        public static Il2CppSystem.Type From(Type type, bool throwOnFailure)
         {
             var pointer = ClassInjector.ReadClassPointerForType(type);
-            return TypeFromPointer(pointer, type.Name);
+            return TypeFromPointerInternal(pointer, type.Name, throwOnFailure);
         }
-        
-        public static Il2CppSystem.Type Of<T>()
+
+        public static Il2CppSystem.Type Of<T>() => Of<T>(true);
+
+        public static Il2CppSystem.Type Of<T>(bool throwOnFailure)
         {
             var classPointer = Il2CppClassPointerStore<T>.NativeClassPtr;
-            return TypeFromPointer(classPointer, typeof(T).Name);
+            return TypeFromPointerInternal(classPointer, typeof(T).Name, throwOnFailure);
         }
     }
 


### PR DESCRIPTION
This pull request adds an optional parameter to Of and From via an override. Previously, Unhollower would throw an exception if the type did not have a corresponding Il2Cpp type. This parameter allows the user to have it return null instead of throwing the exception.