### PR TITLE
Added a method to copy the method info structs

### DIFF
--- a/UnhollowerBaseLib/Runtime/UnityVersionHandler.cs
+++ b/UnhollowerBaseLib/Runtime/UnityVersionHandler.cs
@@ -78,9 +78,9 @@ namespace UnhollowerBaseLib.Runtime
         }
 
         private static Type GetMethodInfoStructType()
-		{
+        {
             return GetHandler<INativeMethodStructHandler>().StructType;
-		}
+        }
 
         public static IntPtr CopyMethodInfoStruct(IntPtr origMethodInfo)
         {

--- a/UnhollowerBaseLib/Runtime/UnityVersionHandler.cs
+++ b/UnhollowerBaseLib/Runtime/UnityVersionHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using UnhollowerBaseLib.Runtime.VersionSpecific.Class;
 using UnhollowerBaseLib.Runtime.VersionSpecific.Image;
 using UnhollowerBaseLib.Runtime.VersionSpecific.MethodInfo;
@@ -74,6 +75,22 @@ namespace UnhollowerBaseLib.Runtime
             LogSupport.Error($"No direct for {typeof(T).FullName} found for Unity {UnityVersion}; this likely indicates a severe error somewhere");
 
             throw new ApplicationException("No handler");
+        }
+
+        private static Type GetMethodInfoStructType()
+		{
+            return GetHandler<INativeMethodStructHandler>().StructType;
+		}
+
+        public static IntPtr CopyMethodInfoStruct(IntPtr origMethodInfo)
+        {
+            int sizeOfMethodInfo = Marshal.SizeOf(GetMethodInfoStructType());
+            IntPtr copiedMethodInfo = Marshal.AllocHGlobal(sizeOfMethodInfo);
+
+            object temp = Marshal.PtrToStructure(origMethodInfo, GetMethodInfoStructType());
+            Marshal.StructureToPtr(temp, copiedMethodInfo, false);
+
+            return copiedMethodInfo;
         }
 
         private static Type[] GetAllTypesSafe()

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/MethodInfo/Interfaces.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/MethodInfo/Interfaces.cs
@@ -7,6 +7,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.MethodInfo
         INativeMethodStruct CreateNewMethodStruct();
         unsafe INativeMethodStruct Wrap(Il2CppMethodInfo* methodPointer);
         IntPtr GetMethodFromReflection(IntPtr method);
+        Type StructType { get; }
     }
 
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/MethodInfo/Method_24.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/MethodInfo/Method_24.cs
@@ -27,6 +27,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.MethodInfo
             return il2cpp_method_get_from_reflection(method);
         }
 
+        public Type StructType => typeof(Il2CppMethodInfoU2018);
+
         [StructLayout(LayoutKind.Sequential)]
         private struct Il2CppMethodInfoU2018
         {

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/MethodInfo/Method_24_1.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/MethodInfo/Method_24_1.cs
@@ -27,6 +27,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.MethodInfo
             return il2cpp_method_get_from_reflection(method);
         }
 
+        public Type StructType => typeof(Il2CppMethodInfoU2018);
+
         [StructLayout(LayoutKind.Sequential)]
         private struct Il2CppMethodInfoU2018
         {


### PR DESCRIPTION
This adds the `CopyMethodInfoStruct` method from [MelonLoader](https://github.com/LavaGang/MelonLoader) in order to fix the compatibility issue between it and this new version of Unhollower.