### PR TITLE
Add support for newer Unity versions

### DIFF
--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_20_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_20_0.cs
@@ -27,8 +27,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Assembly
         [StructLayout(LayoutKind.Sequential)]
         internal struct Il2CppAssembly_20_0
         {
-            public Il2CppImage* image;
-            public IntPtr customAttribute;
+            public int imageIndex;
+            public int customAttributeIndex;
             public int referencedAssemblyStart;
             public int referencedAssemblyCount;
             public Il2CppAssemblyName_20_0 aname;
@@ -64,7 +64,9 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Assembly
 
             private Il2CppAssembly_20_0* NativeAssembly => (Il2CppAssembly_20_0*)Pointer;
 
-            public ref Il2CppImage* Image => ref NativeAssembly->image;
+            private Il2CppImage* dummyImagePointer;
+
+            public ref Il2CppImage* Image => ref dummyImagePointer;
 
             public ref IntPtr Name => ref NativeAssembly->aname.name;
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_24_0_B.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_24_0_B.cs
@@ -3,14 +3,14 @@ using System.Runtime.InteropServices;
 
 namespace UnhollowerBaseLib.Runtime.VersionSpecific.Assembly
 {
-    [ApplicableToUnityVersionsSince("5.3.0")]
-    public unsafe class NativeAssemblyStructHandler_16_0 : INativeAssemblyStructHandler
+    [ApplicableToUnityVersionsSince("2018.1.0")]
+    public unsafe class NativeAssemblyStructHandler_24_0_B : INativeAssemblyStructHandler
     {
         public INativeAssemblyStruct CreateNewAssemblyStruct()
         {
-            var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppAssembly_16_0>());
+            var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppAssembly_24_0_B>());
 
-            *(Il2CppAssembly_16_0*)pointer = default;
+            *(Il2CppAssembly_24_0_B*)pointer = default;
 
             return new NativeAssemblyStruct(pointer);
         }
@@ -21,19 +21,21 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Assembly
         }
 
 #if DEBUG
-        public string GetName() => "NativeAssemblyStructHandler_16_0";
+        public string GetName() => "NativeAssemblyStructHandler_24_0_B";
 #endif
 
         [StructLayout(LayoutKind.Sequential)]
-        internal struct Il2CppAssembly_16_0
+        internal struct Il2CppAssembly_24_0_B
         {
-            public int imageIndex;
+            public Il2CppImage* image;
             public int customAttributeIndex;
-            public Il2CppAssemblyName_16_0 aname;
+            public int referencedAssemblyStart;
+            public int referencedAssemblyCount;
+            public Il2CppAssemblyName_24_0_B aname;
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        internal struct Il2CppAssemblyName_16_0
+        internal struct Il2CppAssemblyName_24_0_B
         {
             public IntPtr name; // const char* 
             public IntPtr culture; // const char*
@@ -60,11 +62,9 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Assembly
 
             public Il2CppAssembly* AssemblyPointer => (Il2CppAssembly*)Pointer;
 
-            private Il2CppAssembly_16_0* NativeAssembly => (Il2CppAssembly_16_0*)Pointer;
+            private Il2CppAssembly_24_0_B* NativeAssembly => (Il2CppAssembly_24_0_B*)Pointer;
 
-            private Il2CppImage* dummyImagePointer;
-
-            public ref Il2CppImage* Image => ref dummyImagePointer;
+            public ref Il2CppImage* Image => ref NativeAssembly->image;
 
             public ref IntPtr Name => ref NativeAssembly->aname.name;
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_24_4.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_24_4.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace UnhollowerBaseLib.Runtime.VersionSpecific.Assembly
 {
+    [ApplicableToUnityVersionsSince("2018.4.34")]
     [ApplicableToUnityVersionsSince("2019.4.15")]
     [ApplicableToUnityVersionsSince("2020.1.11")]
     public unsafe class NativeAssemblyStructHandler_24_4 : INativeAssemblyStructHandler

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_27_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_27_0.cs
@@ -42,8 +42,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
             public Il2CppClass* parent; // not const
             public /*Il2CppGenericClass**/ IntPtr generic_class;
 
-            public IntPtr
-                typeMetadataHandle; //  // const; non-NULL for Il2CppClass's constructed from type defintions
+            public IntPtr typeMetadataHandle; // not const; non-NULL for Il2CppClass's constructed from type defintions
 
             public /*Il2CppInteropData**/ IntPtr interopData; // const
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/EventInfo/EventInfo_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/EventInfo/EventInfo_16_0.cs
@@ -33,7 +33,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.EventInfo
             public Il2CppMethodInfo* add; // const
             public Il2CppMethodInfo* remove; // const
             public Il2CppMethodInfo* raise; // const
-            public IntPtr customAttributeIndex;
+            public int customAttributeIndex;
         }
 
         internal class NativeEventInfoStruct : INativeEventInfoStruct

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/EventInfo/EventInfo_19_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/EventInfo/EventInfo_19_0.cs
@@ -33,7 +33,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.EventInfo
             public Il2CppMethodInfo* add; // const
             public Il2CppMethodInfo* remove; // const
             public Il2CppMethodInfo* raise; // const
-            public IntPtr customAttributeIndex;
+            public int customAttributeIndex;
             public uint token;
         }
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/FieldInfo/FieldInfo_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/FieldInfo/FieldInfo_16_0.cs
@@ -31,7 +31,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.FieldInfo
             public Il2CppTypeStruct* type; // const
             public Il2CppClass* parent; // non-const?
             public int offset; // If offset is -1, then it's thread static
-            public IntPtr customAttributeIndex;
+            public int customAttributeIndex;
         }
 
         internal class NativeFieldInfoStruct : INativeFieldInfoStruct

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/FieldInfo/FieldInfo_19_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/FieldInfo/FieldInfo_19_0.cs
@@ -31,7 +31,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.FieldInfo
             public Il2CppTypeStruct* type; // const
             public Il2CppClass* parent; // non-const?
             public int offset; // If offset is -1, then it's thread static
-            public IntPtr customAttributeIndex;
+            public int customAttributeIndex;
             public uint token;
         }
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/PropertyInfo/PropertyInfo_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/PropertyInfo/PropertyInfo_16_0.cs
@@ -32,7 +32,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.PropertyInfo
             public Il2CppMethodInfo* get; // const
             public Il2CppMethodInfo* set; // const
             public uint attrs;
-            public IntPtr customAttributeIndex;
+            public int customAttributeIndex;
         }
 
         internal class NativePropertyInfoStruct : INativePropertyInfoStruct

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/PropertyInfo/PropertyInfo_19_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/PropertyInfo/PropertyInfo_19_0.cs
@@ -32,7 +32,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.PropertyInfo
             public Il2CppMethodInfo* get; // const
             public Il2CppMethodInfo* set; // const
             public uint attrs;
-            public IntPtr customAttributeIndex;
+            public int customAttributeIndex;
             public uint token;
         }
 


### PR DESCRIPTION
This pull request:
* Adds assembly struct support for Unity 2018.4.34+ which would have otherwise had mismatching. The current 2019, 2020, and 2021 Unity versions seem to be well-handled already by existing struct handlers.
* Fixes some struct mismatching in earlier Unity versions