### PR TITLE
Fix Wrapping Zero Pointer

### DIFF
--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_16_0.cs
@@ -17,7 +17,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Assembly
 
         public INativeAssemblyStruct Wrap(Il2CppAssembly* assemblyPointer)
         {
-            return new NativeAssemblyStruct((IntPtr)assemblyPointer);
+            if ((IntPtr)assemblyPointer == IntPtr.Zero) return null;
+            else return new NativeAssemblyStruct((IntPtr)assemblyPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_20_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_20_0.cs
@@ -17,7 +17,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Assembly
 
         public INativeAssemblyStruct Wrap(Il2CppAssembly* assemblyPointer)
         {
-            return new NativeAssemblyStruct((IntPtr)assemblyPointer);
+            if ((IntPtr)assemblyPointer == IntPtr.Zero) return null;
+            else return new NativeAssemblyStruct((IntPtr)assemblyPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_24_0_B.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_24_0_B.cs
@@ -17,7 +17,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Assembly
 
         public INativeAssemblyStruct Wrap(Il2CppAssembly* assemblyPointer)
         {
-            return new NativeAssemblyStruct((IntPtr)assemblyPointer);
+            if ((IntPtr)assemblyPointer == IntPtr.Zero) return null;
+            else return new NativeAssemblyStruct((IntPtr)assemblyPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_24_1.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_24_1.cs
@@ -18,7 +18,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Assembly
 
         public INativeAssemblyStruct Wrap(Il2CppAssembly* assemblyPointer)
         {
-            return new NativeAssemblyStruct((IntPtr)assemblyPointer);
+            if ((IntPtr)assemblyPointer == IntPtr.Zero) return null;
+            else return new NativeAssemblyStruct((IntPtr)assemblyPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_24_4.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_24_4.cs
@@ -19,7 +19,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Assembly
 
         public INativeAssemblyStruct Wrap(Il2CppAssembly* assemblyPointer)
         {
-            return new NativeAssemblyStruct((IntPtr)assemblyPointer);
+            if ((IntPtr)assemblyPointer == IntPtr.Zero) return null;
+            else return new NativeAssemblyStruct((IntPtr)assemblyPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_16_0.cs
@@ -28,7 +28,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
         public unsafe INativeClassStruct Wrap(Il2CppClass* classPointer)
         {
-            return new NativeClassStructWrapper((IntPtr)classPointer);
+            if ((IntPtr)classPointer == IntPtr.Zero) return null;
+            else return new NativeClassStructWrapper((IntPtr)classPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_19_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_19_0.cs
@@ -28,7 +28,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
         public unsafe INativeClassStruct Wrap(Il2CppClass* classPointer)
         {
-            return new NativeClassStructWrapper((IntPtr)classPointer);
+            if ((IntPtr)classPointer == IntPtr.Zero) return null;
+            else return new NativeClassStructWrapper((IntPtr)classPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_20_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_20_0.cs
@@ -28,7 +28,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
         public unsafe INativeClassStruct Wrap(Il2CppClass* classPointer)
         {
-            return new NativeClassStructWrapper((IntPtr)classPointer);
+            if ((IntPtr)classPointer == IntPtr.Zero) return null;
+            else return new NativeClassStructWrapper((IntPtr)classPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_21_0_B.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_21_0_B.cs
@@ -27,7 +27,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
         public unsafe INativeClassStruct Wrap(Il2CppClass* classPointer)
         {
-            return new NativeClassStructWrapper((IntPtr)classPointer);
+            if ((IntPtr)classPointer == IntPtr.Zero) return null;
+            else return new NativeClassStructWrapper((IntPtr)classPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_21_0_C.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_21_0_C.cs
@@ -27,7 +27,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
         public unsafe INativeClassStruct Wrap(Il2CppClass* classPointer)
         {
-            return new NativeClassStructWrapper((IntPtr)classPointer);
+            if ((IntPtr)classPointer == IntPtr.Zero) return null;
+            else return new NativeClassStructWrapper((IntPtr)classPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_22_0_A.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_22_0_A.cs
@@ -25,7 +25,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
         public unsafe INativeClassStruct Wrap(Il2CppClass* classPointer)
         {
-            return new NativeClassStructWrapper((IntPtr)classPointer);
+            if ((IntPtr)classPointer == IntPtr.Zero) return null;
+            else return new NativeClassStructWrapper((IntPtr)classPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_22_0_B.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_22_0_B.cs
@@ -25,7 +25,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
         public unsafe INativeClassStruct Wrap(Il2CppClass* classPointer)
         {
-            return new NativeClassStructWrapper((IntPtr)classPointer);
+            if ((IntPtr)classPointer == IntPtr.Zero) return null;
+            else return new NativeClassStructWrapper((IntPtr)classPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_23_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_23_0.cs
@@ -25,7 +25,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
         public unsafe INativeClassStruct Wrap(Il2CppClass* classPointer)
         {
-            return new NativeClassStructWrapper((IntPtr)classPointer);
+            if ((IntPtr)classPointer == IntPtr.Zero) return null;
+            else return new NativeClassStructWrapper((IntPtr)classPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_0_B.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_0_B.cs
@@ -19,7 +19,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
         public unsafe INativeClassStruct Wrap(Il2CppClass* classPointer)
         {
-            return new NativeClassStructWrapper((IntPtr)classPointer);
+            if ((IntPtr)classPointer == IntPtr.Zero) return null;
+            else return new NativeClassStructWrapper((IntPtr)classPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_0_C.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_0_C.cs
@@ -19,7 +19,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
         public unsafe INativeClassStruct Wrap(Il2CppClass* classPointer)
         {
-            return new NativeClassStructWrapper((IntPtr)classPointer);
+            if ((IntPtr)classPointer == IntPtr.Zero) return null;
+            else return new NativeClassStructWrapper((IntPtr)classPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_1_A.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_1_A.cs
@@ -19,7 +19,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
         public unsafe INativeClassStruct Wrap(Il2CppClass* classPointer)
         {
-            return new NativeClassStructWrapper((IntPtr)classPointer);
+            if ((IntPtr)classPointer == IntPtr.Zero) return null;
+            else return new NativeClassStructWrapper((IntPtr)classPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_1_B.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_1_B.cs
@@ -19,7 +19,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
         public unsafe INativeClassStruct Wrap(Il2CppClass* classPointer)
         {
-            return new NativeClassStructWrapper((IntPtr)classPointer);
+            if ((IntPtr)classPointer == IntPtr.Zero) return null;
+            else return new NativeClassStructWrapper((IntPtr)classPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_2.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_2.cs
@@ -19,7 +19,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
         public unsafe INativeClassStruct Wrap(Il2CppClass* classPointer)
         {
-            return new NativeClassStruct((IntPtr)classPointer);
+            if ((IntPtr) classPointer == IntPtr.Zero) return null;
+            else return new NativeClassStruct((IntPtr)classPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_27_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_27_0.cs
@@ -19,7 +19,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
         public unsafe INativeClassStruct Wrap(Il2CppClass* classPointer)
         {
-            return new NativeClassStruct((IntPtr)classPointer);
+            if ((IntPtr)classPointer == IntPtr.Zero) return null;
+            else return new NativeClassStruct((IntPtr)classPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_27_2.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_27_2.cs
@@ -19,7 +19,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
         public unsafe INativeClassStruct Wrap(Il2CppClass* classPointer)
         {
-            return new NativeClassStruct((IntPtr)classPointer);
+            if ((IntPtr)classPointer == IntPtr.Zero) return null;
+            else return new NativeClassStruct((IntPtr)classPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/EventInfo/EventInfo_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/EventInfo/EventInfo_16_0.cs
@@ -17,7 +17,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.EventInfo
 
         public INativeEventInfoStruct Wrap(Il2CppEventInfo* eventInfoPointer)
         {
-            return new NativeEventInfoStruct((IntPtr)eventInfoPointer);
+            if ((IntPtr)eventInfoPointer == IntPtr.Zero) return null;
+            else return new NativeEventInfoStruct((IntPtr)eventInfoPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/EventInfo/EventInfo_19_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/EventInfo/EventInfo_19_0.cs
@@ -17,7 +17,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.EventInfo
 
         public INativeEventInfoStruct Wrap(Il2CppEventInfo* eventInfoPointer)
         {
-            return new NativeEventInfoStruct((IntPtr)eventInfoPointer);
+            if ((IntPtr)eventInfoPointer == IntPtr.Zero) return null;
+            else return new NativeEventInfoStruct((IntPtr)eventInfoPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/EventInfo/EventInfo_24_1.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/EventInfo/EventInfo_24_1.cs
@@ -17,7 +17,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.EventInfo
 
         public INativeEventInfoStruct Wrap(Il2CppEventInfo* eventInfoPointer)
         {
-            return new NativeEventInfoStruct((IntPtr)eventInfoPointer);
+            if ((IntPtr)eventInfoPointer == IntPtr.Zero) return null;
+            else return new NativeEventInfoStruct((IntPtr)eventInfoPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/FieldInfo/FieldInfo_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/FieldInfo/FieldInfo_16_0.cs
@@ -17,7 +17,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.FieldInfo
 
         public INativeFieldInfoStruct Wrap(Il2CppFieldInfo* fieldInfoPointer)
         {
-            return new NativeFieldInfoStruct((IntPtr)fieldInfoPointer);
+            if ((IntPtr)fieldInfoPointer == IntPtr.Zero) return null;
+            else return new NativeFieldInfoStruct((IntPtr)fieldInfoPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/FieldInfo/FieldInfo_19_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/FieldInfo/FieldInfo_19_0.cs
@@ -17,7 +17,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.FieldInfo
 
         public INativeFieldInfoStruct Wrap(Il2CppFieldInfo* fieldInfoPointer)
         {
-            return new NativeFieldInfoStruct((IntPtr)fieldInfoPointer);
+            if ((IntPtr)fieldInfoPointer == IntPtr.Zero) return null;
+            else return new NativeFieldInfoStruct((IntPtr)fieldInfoPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/FieldInfo/FieldInfo_24_1.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/FieldInfo/FieldInfo_24_1.cs
@@ -17,7 +17,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.FieldInfo
 
         public INativeFieldInfoStruct Wrap(Il2CppFieldInfo* fieldInfoPointer)
         {
-            return new NativeFieldInfoStruct((IntPtr)fieldInfoPointer);
+            if ((IntPtr)fieldInfoPointer == IntPtr.Zero) return null;
+            else return new NativeFieldInfoStruct((IntPtr)fieldInfoPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_16_0.cs
@@ -17,7 +17,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Image
 
         public INativeImageStruct Wrap(Il2CppImage* imagePointer)
         {
-            return new NativeImageStruct((IntPtr)imagePointer);
+            if ((IntPtr)imagePointer == IntPtr.Zero) return null;
+            else return new NativeImageStruct((IntPtr)imagePointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_19_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_19_0.cs
@@ -17,7 +17,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Image
 
         public INativeImageStruct Wrap(Il2CppImage* imagePointer)
         {
-            return new NativeImageStruct((IntPtr)imagePointer);
+            if ((IntPtr)imagePointer == IntPtr.Zero) return null;
+            else return new NativeImageStruct((IntPtr)imagePointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_0_A.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_0_A.cs
@@ -18,7 +18,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Image
 
         public INativeImageStruct Wrap(Il2CppImage* imagePointer)
         {
-            return new NativeImageStruct((IntPtr)imagePointer);
+            if ((IntPtr)imagePointer == IntPtr.Zero) return null;
+            else return new NativeImageStruct((IntPtr)imagePointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_0_B.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_0_B.cs
@@ -18,7 +18,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Image
 
         public INativeImageStruct Wrap(Il2CppImage* imagePointer)
         {
-            return new NativeImageStruct((IntPtr)imagePointer);
+            if ((IntPtr)imagePointer == IntPtr.Zero) return null;
+            else return new NativeImageStruct((IntPtr)imagePointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_0_C.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_0_C.cs
@@ -17,7 +17,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Image
 
         public INativeImageStruct Wrap(Il2CppImage* imagePointer)
         {
-            return new NativeImageStruct((IntPtr)imagePointer);
+            if ((IntPtr)imagePointer == IntPtr.Zero) return null;
+            else return new NativeImageStruct((IntPtr)imagePointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_1.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_1.cs
@@ -17,7 +17,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Image
 
         public INativeImageStruct Wrap(Il2CppImage* imagePointer)
         {
-            return new NativeImageStruct((IntPtr)imagePointer);
+            if ((IntPtr)imagePointer == IntPtr.Zero) return null;
+            else return new NativeImageStruct((IntPtr)imagePointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_2.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_2.cs
@@ -17,7 +17,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Image
 
         public INativeImageStruct Wrap(Il2CppImage* imagePointer)
         {
-            return new NativeImageStruct((IntPtr)imagePointer);
+            if ((IntPtr)imagePointer == IntPtr.Zero) return null;
+            else return new NativeImageStruct((IntPtr)imagePointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_27_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_27_0.cs
@@ -21,7 +21,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Image
 
         public INativeImageStruct Wrap(Il2CppImage* imagePointer)
         {
-            return new NativeImageStruct((IntPtr)imagePointer);
+            if ((IntPtr)imagePointer == IntPtr.Zero) return null;
+            else return new NativeImageStruct((IntPtr)imagePointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/MethodInfo/MethodInfo_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/MethodInfo/MethodInfo_16_0.cs
@@ -16,7 +16,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.MethodInfo
 
         public INativeMethodInfoStruct Wrap(Il2CppMethodInfo* methodPointer)
         {
-            return new NativeMethodInfoStructWrapper((IntPtr)methodPointer);
+            if ((IntPtr)methodPointer == IntPtr.Zero) return null;
+            else return new NativeMethodInfoStructWrapper((IntPtr)methodPointer);
         }
 
         [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/MethodInfo/MethodInfo_24_1.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/MethodInfo/MethodInfo_24_1.cs
@@ -16,7 +16,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.MethodInfo
 
         public INativeMethodInfoStruct Wrap(Il2CppMethodInfo* methodPointer)
         {
-            return new NativeMethodInfoStructWrapper((IntPtr)methodPointer);
+            if ((IntPtr)methodPointer == IntPtr.Zero) return null;
+            else return new NativeMethodInfoStructWrapper((IntPtr)methodPointer);
         }
 
         [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/ParameterInfo/ParameterInfo_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/ParameterInfo/ParameterInfo_16_0.cs
@@ -20,7 +20,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.ParameterInfo
 
         public unsafe INativeParameterInfoStruct Wrap(Il2CppParameterInfo* paramInfoPointer)
         {
-            return new NativeParameterInfoStructWrapper((IntPtr) paramInfoPointer);
+            if ((IntPtr)paramInfoPointer == IntPtr.Zero) return null;
+            else return new NativeParameterInfoStructWrapper((IntPtr) paramInfoPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/ParameterInfo/ParameterInfo_24_1.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/ParameterInfo/ParameterInfo_24_1.cs
@@ -20,7 +20,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.ParameterInfo
 
         public unsafe INativeParameterInfoStruct Wrap(Il2CppParameterInfo* paramInfoPointer)
         {
-            return new NativeParameterInfoStructWrapper((IntPtr) paramInfoPointer);
+            if ((IntPtr)paramInfoPointer == IntPtr.Zero) return null;
+            else return new NativeParameterInfoStructWrapper((IntPtr) paramInfoPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/PropertyInfo/PropertyInfo_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/PropertyInfo/PropertyInfo_16_0.cs
@@ -17,7 +17,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.PropertyInfo
 
         public INativePropertyInfoStruct Wrap(Il2CppPropertyInfo* propertyInfoPointer)
         {
-            return new NativePropertyInfoStruct((IntPtr)propertyInfoPointer);
+            if ((IntPtr)propertyInfoPointer == IntPtr.Zero) return null;
+            else return new NativePropertyInfoStruct((IntPtr)propertyInfoPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/PropertyInfo/PropertyInfo_19_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/PropertyInfo/PropertyInfo_19_0.cs
@@ -17,7 +17,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.PropertyInfo
 
         public INativePropertyInfoStruct Wrap(Il2CppPropertyInfo* propertyInfoPointer)
         {
-            return new NativePropertyInfoStruct((IntPtr)propertyInfoPointer);
+            if ((IntPtr)propertyInfoPointer == IntPtr.Zero) return null;
+            else return new NativePropertyInfoStruct((IntPtr)propertyInfoPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/PropertyInfo/PropertyInfo_24_1.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/PropertyInfo/PropertyInfo_24_1.cs
@@ -17,7 +17,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.PropertyInfo
 
         public INativePropertyInfoStruct Wrap(Il2CppPropertyInfo* propertyInfoPointer)
         {
-            return new NativePropertyInfoStruct((IntPtr)propertyInfoPointer);
+            if ((IntPtr)propertyInfoPointer == IntPtr.Zero) return null;
+            else return new NativePropertyInfoStruct((IntPtr)propertyInfoPointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Interfaces.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Interfaces.cs
@@ -5,7 +5,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Type
     public interface INativeTypeStructHandler : INativeStructHandler
     {
         INativeTypeStruct CreateNewTypeStruct();
-        unsafe INativeTypeStruct Wrap(Il2CppTypeStruct* imagePointer);
+        unsafe INativeTypeStruct Wrap(Il2CppTypeStruct* typePointer);
 #if DEBUG
         string GetName();
 #endif

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Type_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Type_16_0.cs
@@ -15,9 +15,10 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Type
             return new NativeTypeStruct(pointer);
         }
 
-        public INativeTypeStruct Wrap(Il2CppTypeStruct* TypePointer)
+        public INativeTypeStruct Wrap(Il2CppTypeStruct* typePointer)
         {
-            return new NativeTypeStruct((IntPtr)TypePointer);
+            if ((IntPtr)typePointer == IntPtr.Zero) return null;
+            else return new NativeTypeStruct((IntPtr)typePointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Type_27_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Type_27_0.cs
@@ -15,9 +15,10 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Type
             return new NativeTypeStruct(pointer);
         }
 
-        public INativeTypeStruct Wrap(Il2CppTypeStruct* TypePointer)
+        public INativeTypeStruct Wrap(Il2CppTypeStruct* typePointer)
         {
-            return new NativeTypeStruct((IntPtr)TypePointer);
+            if ((IntPtr)typePointer == IntPtr.Zero) return null;
+            else return new NativeTypeStruct((IntPtr)typePointer);
         }
 
 #if DEBUG

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Type_27_2.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Type_27_2.cs
@@ -15,9 +15,10 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Type
             return new NativeTypeStruct(pointer);
         }
 
-        public INativeTypeStruct Wrap(Il2CppTypeStruct* TypePointer)
+        public INativeTypeStruct Wrap(Il2CppTypeStruct* typePointer)
         {
-            return new NativeTypeStruct((IntPtr)TypePointer);
+            if ((IntPtr)typePointer == IntPtr.Zero) return null;
+            else return new NativeTypeStruct((IntPtr)typePointer);
         }
 
 #if DEBUG


### PR DESCRIPTION
Fixes an issue where the zero pointer could be wrapped.

This would cause issues during class injection where [wrapping the base class pointer](https://github.com/knah/Il2CppAssemblyUnhollower/blob/9f622e324f62076c3f214c1f52c9d979794852bd/UnhollowerBaseLib/ClassInjector.cs#L85) could not return null.