### PR TITLE
Added support for Unity 2021.2.0

### DIFF
--- a/UnhollowerBaseLib/ClassInjector.cs
+++ b/UnhollowerBaseLib/ClassInjector.cs
@@ -283,9 +283,12 @@ namespace UnhollowerRuntimeLib
                 {
                     var parameterInfo = parameters[i];
                     var param = UnityVersionHandler.Wrap(paramsArray[i]);
-                    param.Name = Marshal.StringToHGlobalAnsi(parameterInfo.Name);
-                    param.Position = i;
-                    param.Token = 0;
+                    if (UnityVersionHandler.ParameterInfoHasNamePosToken())
+                    {
+                        param.Name = Marshal.StringToHGlobalAnsi(parameterInfo.Name);
+                        param.Position = i;
+                        param.Token = 0;
+                    }
                     param.ParameterType = (Il2CppTypeStruct*)IL2CPP.il2cpp_class_get_type(ReadClassPointerForType(parameterInfo.ParameterType));
                 }
             }

--- a/UnhollowerBaseLib/Runtime/UnityVersionHandler.cs
+++ b/UnhollowerBaseLib/Runtime/UnityVersionHandler.cs
@@ -168,6 +168,9 @@ namespace UnhollowerBaseLib.Runtime
 
         public static unsafe INativeParameterInfoStruct Wrap(Il2CppParameterInfo* parameterInfo) =>
             GetHandler<INativeParameterInfoStructHandler>().Wrap(parameterInfo);
+        
+        public static bool ParameterInfoHasNamePosToken() =>
+            GetHandler<INativeParameterInfoStructHandler>().HasNamePosToken;
 
 
         //Properties

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_27_3.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_27_3.cs
@@ -1,0 +1,261 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using UnhollowerBaseLib.Runtime.VersionSpecific.Type;
+
+namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
+{
+    [ApplicableToUnityVersionsSince("2021.2.0")]
+    public class NativeClassStructHandler_27_3 : INativeClassStructHandler
+    {
+        public unsafe INativeClassStruct CreateNewClassStruct(int vTableSlots)
+        {
+            var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppClass_27_3>() +
+                                               Marshal.SizeOf<VirtualInvokeData>() * vTableSlots);
+
+            *(Il2CppClass_27_3*)pointer = default;
+
+            return new NativeClassStruct(pointer);
+        }
+
+        public unsafe INativeClassStruct Wrap(Il2CppClass* classPointer)
+        {
+            if ((IntPtr)classPointer == IntPtr.Zero) return null;
+            else return new NativeClassStruct((IntPtr)classPointer);
+        }
+
+#if DEBUG
+        public string GetName() => "NativeClassStructHandler_27_3";
+#endif
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct Il2CppClass_27_3
+        {
+            // The following fields are always valid for a Il2CppClass structure
+            public Il2CppImage* image; // const
+            public IntPtr gc_desc;
+            public IntPtr name; // const char*
+            public IntPtr namespaze; // const char*
+            public NativeTypeStructHandler_27_2.Il2CppType_27_2 byval_arg; // not const, no ptr
+            public NativeTypeStructHandler_27_2.Il2CppType_27_2 this_arg; // not const, no ptr
+            public Il2CppClass* element_class; // not const
+            public Il2CppClass* castClass; // not const
+            public Il2CppClass* declaringType; // not const
+            public Il2CppClass* parent; // not const
+            public /*Il2CppGenericClass**/ IntPtr generic_class;
+
+            public IntPtr
+                typeMetadataHandle; //  // const; non-NULL for Il2CppClass's constructed from type defintions
+
+            public /*Il2CppInteropData**/ IntPtr interopData; // const
+
+            public Il2CppClass* klass; // not const; hack to pretend we are a MonoVTable. Points to ourself
+            // End always valid fields
+
+            // The following fields need initialized before access. This can be done per field or as an aggregate via a call to Class::Init
+            public Il2CppFieldInfo* fields; // Initialized in SetupFields
+            public Il2CppEventInfo* events; // const; Initialized in SetupEvents
+            public Il2CppPropertyInfo* properties; // const; Initialized in SetupProperties
+            public Il2CppMethodInfo** methods; // const; Initialized in SetupMethods
+            public Il2CppClass** nestedTypes; // not const; Initialized in SetupNestedTypes
+            public Il2CppClass** implementedInterfaces; // not const; Initialized in SetupInterfaces
+            public Il2CppRuntimeInterfaceOffsetPair* interfaceOffsets; // not const; Initialized in Init
+            public IntPtr static_fields; // not const; Initialized in Init
+            public /*Il2CppRGCTXData**/ IntPtr rgctx_data; // const; Initialized in Init
+
+            // used for fast parent checks
+            public Il2CppClass** typeHierarchy; // not const; Initialized in SetupTypeHierachy
+            // End initialization required fields
+
+            // public IntPtr typeDefinition;
+
+            // U2020 specific field
+            public IntPtr unity_user_data;
+
+            public uint initializationExceptionGCHandle;
+
+
+            public uint cctor_started;
+            public uint cctor_finished_or_no_cctor;
+
+            ///*ALIGN_TYPE(8)*/
+            public IntPtr cctor_thread; // was uint64 in 2018.4, is size_t in >=2019.3.1
+
+
+            ///*ALIGN_TYPE(8)*/ IntPtr cctor_thread; // was uint64 in 2018.4, is size_t in 2020.3.1
+
+            // Remaining fields are always valid except where noted
+            //public /*GenericContainerIndex*/ int genericContainerIndex;
+            public IntPtr genericContainerHandle;
+
+            public uint instance_size;
+            public uint actualSize;
+            public uint element_size;
+            public int native_size;
+            public uint static_fields_size;
+            public uint thread_static_fields_size;
+            public int thread_static_fields_offset;
+            public Il2CppClassAttributes flags;
+            public uint token;
+
+            public ushort method_count; // lazily calculated for arrays, i.e. when rank > 0
+            public ushort property_count;
+            public ushort field_count;
+            public ushort event_count;
+            public ushort nested_type_count;
+            public ushort vtable_count; // lazily calculated for arrays, i.e. when rank > 0
+            public ushort interfaces_count;
+            public ushort interface_offsets_count; // lazily calculated for arrays, i.e. when rank > 0
+
+            public byte typeHierarchyDepth; // Initialized in SetupTypeHierachy
+            public byte genericRecursionDepth;
+            public byte rank;
+            public byte minimumAlignment; // Alignment of this type
+            public byte naturalAligment; // Alignment of this type without accounting for packing
+            public byte packingSize;
+
+            // this is critical for performance of Class::InitFromCodegen. Equals to initialized && !has_initialization_error at all times.
+            // Use Class::UpdateInitializedAndNoError to update
+            public byte bitfield_1;
+            //uint8_t initialized_and_no_error : 1;
+            //uint8_t initialized : 1;
+            //uint8_t enumtype : 1;
+            //uint8_t nullabletype : 1;
+            //uint8_t is_generic : 1;
+            //uint8_t has_references : 1;
+            //uint8_t init_pending : 1;
+            //uint8_t size_inited : 1;
+
+            public byte bitfield_2;
+            //uint8_t has_finalize : 1;
+            //uint8_t has_cctor : 1;
+            //uint8_t is_blittable : 1;
+            //uint8_t is_import_or_windows_runtime : 1;
+            //uint8_t is_vtable_initialized : 1;
+            //uint8_t is_byref_like : 1;
+
+            //VirtualInvokeData vtable[IL2CPP_ZERO_LEN_ARRAY];
+        }
+
+        internal unsafe class NativeClassStruct : INativeClassStruct
+        {
+            public NativeClassStruct(IntPtr pointer)
+            {
+                Pointer = pointer;
+            }
+
+            public IntPtr Pointer { get; }
+            public Il2CppClass* ClassPointer => (Il2CppClass*)Pointer;
+
+            public IntPtr VTable => IntPtr.Add(Pointer, Marshal.SizeOf<Il2CppClass_27_3>());
+
+            private Il2CppClass_27_3* NativeClass => (Il2CppClass_27_3*)Pointer;
+
+            public ref uint InstanceSize => ref NativeClass->instance_size;
+
+            public ref ushort VtableCount => ref NativeClass->vtable_count;
+
+            public ref int NativeSize => ref NativeClass->native_size;
+
+            public ref uint ActualSize => ref NativeClass->actualSize;
+
+            public ref ushort MethodCount => ref NativeClass->method_count;
+
+            // public ref ClassBitfield1 Bitfield1 => ref NativeClass->bitfield_1;
+
+            // public ref ClassBitfield2 Bitfield2 => ref NativeClass->bitfield_2;
+
+            public ref Il2CppClassAttributes Flags => ref NativeClass->flags;
+
+            private static int bitfield1offset =
+                Marshal.OffsetOf<Il2CppClass_27_3>(nameof(Il2CppClass_27_3.bitfield_1)).ToInt32();
+
+            private static int bitfield2offset =
+                Marshal.OffsetOf<Il2CppClass_27_3>(nameof(Il2CppClass_27_3.bitfield_2)).ToInt32();
+
+            private static int byval_arg_mods_byref_pin_offset =
+                Marshal.OffsetOf<Il2CppClass_27_3>(nameof(Il2CppClass_27_3.byval_arg.mods_byref_pin)).ToInt32();
+
+            private static int this_arg_mods_byref_pin_offset =
+                Marshal.OffsetOf<Il2CppClass_27_3>(nameof(Il2CppClass_27_3.this_arg.mods_byref_pin)).ToInt32();
+
+            public bool InitializedAndNoError
+            {
+                get => this.CheckBit(bitfield1offset, 0);
+                set => this.SetBit(bitfield1offset, 0, value);
+            }
+
+            public bool ValueType
+            {
+                get
+                {
+                    return this.CheckBit(byval_arg_mods_byref_pin_offset, 7) && this.CheckBit(this_arg_mods_byref_pin_offset, 7);
+                }
+                set
+                {
+                    this.SetBit(byval_arg_mods_byref_pin_offset, 7, value);
+                    this.SetBit(this_arg_mods_byref_pin_offset, 7, value);
+                }
+            }
+
+            public bool Initialized
+            {
+                get => this.CheckBit(bitfield1offset, 1);
+                set => this.SetBit(bitfield1offset, 1, value);
+            }
+
+            public bool EnumType
+            {
+                get => this.CheckBit(bitfield1offset, 2);
+                set => this.SetBit(bitfield1offset, 2, value);
+            }
+
+            public bool IsGeneric
+            {
+                get => this.CheckBit(bitfield1offset, 4);
+                set => this.SetBit(bitfield1offset, 4, value);
+            }
+
+            public bool SizeInited
+            {
+                get => this.CheckBit(bitfield1offset, 7);
+                set => this.SetBit(bitfield1offset, 7, value);
+            }
+
+            public bool HasFinalize
+            {
+                get => this.CheckBit(bitfield2offset, 0);
+                set => this.SetBit(bitfield2offset, 0, value);
+            }
+
+            public bool IsVtableInitialized
+            {
+                get => this.CheckBit(bitfield2offset, 4);
+                set => this.SetBit(bitfield2offset, 4, value);
+            }
+
+            public ref IntPtr Name => ref NativeClass->name;
+
+            public ref IntPtr Namespace => ref NativeClass->namespaze;
+
+            private Il2CppTypeStruct* ByValArgPointer => (Il2CppTypeStruct*)(&(NativeClass->byval_arg));
+
+            private Il2CppTypeStruct* ThisArgPointer => (Il2CppTypeStruct*)(&(NativeClass->this_arg));
+
+            public INativeTypeStruct ByValArg => UnityVersionHandler.Wrap(ByValArgPointer);
+
+            public INativeTypeStruct ThisArg => UnityVersionHandler.Wrap(ThisArgPointer);
+
+            public ref Il2CppImage* Image => ref NativeClass->image;
+
+            public ref Il2CppClass* Parent => ref NativeClass->parent;
+
+            public ref Il2CppClass* ElementClass => ref NativeClass->element_class;
+
+            public ref Il2CppClass* CastClass => ref NativeClass->castClass;
+
+            public ref Il2CppClass* Class => ref NativeClass->klass;
+
+            public ref Il2CppMethodInfo** Methods => ref NativeClass->methods;
+        }
+    }
+}

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/MethodInfo/MethodInfo_27_3.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/MethodInfo/MethodInfo_27_3.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace UnhollowerBaseLib.Runtime.VersionSpecific.MethodInfo
+{
+    [ApplicableToUnityVersionsSince("2021.2.0")]
+    public unsafe class NativeMethodInfoStructHandler_27_3 : INativeMethodInfoStructHandler
+    {
+        public INativeMethodInfoStruct CreateNewMethodStruct()
+        {
+            var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppMethodInfo_27_3>());
+            *(Il2CppMethodInfo_27_3*)pointer = default;
+
+            return new NativeMethodInfoStructWrapper(pointer);
+        }
+
+        public INativeMethodInfoStruct Wrap(Il2CppMethodInfo* methodPointer)
+        {
+            if ((IntPtr)methodPointer == IntPtr.Zero) return null;
+            else return new NativeMethodInfoStructWrapper((IntPtr)methodPointer);
+        }
+
+        [DllImport("GameAssembly", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        private static extern IntPtr il2cpp_method_get_from_reflection(IntPtr method);
+
+        public IntPtr GetMethodFromReflection(IntPtr method)
+        {
+            return il2cpp_method_get_from_reflection(method);
+        }
+
+        public IntPtr CopyMethodInfoStruct(IntPtr origMethodInfo)
+        {
+            int sizeOfMethodInfo = Marshal.SizeOf<Il2CppMethodInfo_27_3>();
+            IntPtr copiedMethodInfo = Marshal.AllocHGlobal(sizeOfMethodInfo);
+
+            object temp = Marshal.PtrToStructure<Il2CppMethodInfo_27_3>(origMethodInfo);
+            Marshal.StructureToPtr(temp, copiedMethodInfo, false);
+
+            return copiedMethodInfo;
+        }
+
+#if DEBUG
+        public string GetName() => "NativeMethodInfoStructHandler_27_3";
+#endif
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct Il2CppMethodInfo_27_3
+        {
+            public IntPtr methodPointer;
+            public IntPtr virtualMethodPointer;
+            public IntPtr invoker_method;
+            public IntPtr name; // const char*
+            public Il2CppClass* klass;
+            public Il2CppTypeStruct* return_type;
+            
+            public /* Il2CppTypeStruct** */ Il2CppParameterInfo* parameters;
+            // Actually a type pointer array but left as parameter info because
+            // it's the same size, and it makes the wrapper code much cleaner.
+
+            public IntPtr someRtData;
+            /*union
+            {
+                const Il2CppRGCTXData* rgctx_data; /* is_inflated is true and is_generic is false, i.e. a generic instance method #1#
+                const Il2CppMethodDefinition* methodDefinition;
+            };*/
+
+            public IntPtr someGenericData;
+            /*/* note, when is_generic == true and is_inflated == true the method represents an uninflated generic method on an inflated type. #1#
+            union
+            {
+                const Il2CppGenericMethod* genericMethod; /* is_inflated is true #1#
+                const Il2CppGenericContainer* genericContainer; /* is_inflated is false and is_generic is true #1#
+            };*/
+
+            public uint token;
+            public Il2CppMethodFlags flags;
+            public Il2CppMethodImplFlags iflags;
+            public ushort slot;
+            public byte parameters_count;
+
+            public MethodInfoExtraFlags extra_flags;
+            /*uint8_t is_generic : 1; /* true if method is a generic method definition #1#
+            uint8_t is_inflated : 1; /* true if declaring_type is a generic instance or if method is a generic instance#1#
+            uint8_t wrapper_type : 1; /* always zero (MONO_WRAPPER_NONE) needed for the debugger #1#
+            uint8_t is_marshaled_from_native : 1*/
+        }
+
+
+        internal class NativeMethodInfoStructWrapper : INativeMethodInfoStruct
+        {
+            public NativeMethodInfoStructWrapper(IntPtr pointer)
+            {
+                Pointer = pointer;
+            }
+
+            public int StructSize => Marshal.SizeOf<Il2CppMethodInfo_27_3>();
+
+            public IntPtr Pointer { get; }
+
+            public Il2CppMethodInfo* MethodInfoPointer => (Il2CppMethodInfo*)Pointer;
+
+            private Il2CppMethodInfo_27_3* NativeMethod => (Il2CppMethodInfo_27_3*)Pointer;
+
+            public ref IntPtr Name => ref NativeMethod->name;
+
+            public ref ushort Slot => ref NativeMethod->slot;
+
+            public ref IntPtr MethodPointer => ref NativeMethod->methodPointer;
+
+            public ref Il2CppClass* Class => ref NativeMethod->klass;
+
+            public ref IntPtr InvokerMethod => ref NativeMethod->invoker_method;
+
+            public ref Il2CppTypeStruct* ReturnType => ref NativeMethod->return_type;
+
+            public ref Il2CppMethodFlags Flags => ref NativeMethod->flags;
+
+            public ref byte ParametersCount => ref NativeMethod->parameters_count;
+
+            public ref Il2CppParameterInfo* Parameters => ref NativeMethod->parameters;
+
+            public ref MethodInfoExtraFlags ExtraFlags => ref NativeMethod->extra_flags;
+        }
+    }
+}

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/ParameterInfo/Interfaces.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/ParameterInfo/Interfaces.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.ParameterInfo
     {
         unsafe Il2CppParameterInfo*[] CreateNewParameterInfoArray(int paramCount);
         unsafe INativeParameterInfoStruct Wrap(Il2CppParameterInfo* paramInfoPointer);
+        bool HasNamePosToken { get; }
 #if DEBUG
         string GetName();
 #endif
@@ -14,6 +15,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.ParameterInfo
     public interface INativeParameterInfoStruct : INativeStruct
     {
         unsafe Il2CppParameterInfo* ParameterInfoPointer { get; }
+        bool HasNamePosToken { get; }
         ref IntPtr Name { get; }
         ref int Position { get; }
         ref uint Token { get; }

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/ParameterInfo/ParameterInfo_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/ParameterInfo/ParameterInfo_16_0.cs
@@ -24,6 +24,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.ParameterInfo
             else return new NativeParameterInfoStructWrapper((IntPtr) paramInfoPointer);
         }
 
+        public bool HasNamePosToken => true;
+
 #if DEBUG
         public string GetName() => "NativeParameterInfoStructHandler_16_0";
 #endif
@@ -49,7 +51,9 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.ParameterInfo
 
             public Il2CppParameterInfo* ParameterInfoPointer => (Il2CppParameterInfo*)Pointer;
 
-            public Il2CppParameterInfo_16_0* NativeParameter => (Il2CppParameterInfo_16_0*)Pointer;
+            public bool HasNamePosToken => true;
+
+            private Il2CppParameterInfo_16_0* NativeParameter => (Il2CppParameterInfo_16_0*)Pointer;
 
             public ref IntPtr Name => ref NativeParameter->name;
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/ParameterInfo/ParameterInfo_24_1.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/ParameterInfo/ParameterInfo_24_1.cs
@@ -24,6 +24,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.ParameterInfo
             else return new NativeParameterInfoStructWrapper((IntPtr) paramInfoPointer);
         }
 
+        public bool HasNamePosToken => true;
+
 #if DEBUG
         public string GetName() => "NativeParameterInfoStructHandler_24_1";
 #endif
@@ -48,7 +50,9 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.ParameterInfo
 
             public Il2CppParameterInfo* ParameterInfoPointer => (Il2CppParameterInfo*)Pointer;
 
-            public Il2CppParameterInfo_24_1* NativeParameter => (Il2CppParameterInfo_24_1*)Pointer;
+            public bool HasNamePosToken => true;
+
+            private Il2CppParameterInfo_24_1* NativeParameter => (Il2CppParameterInfo_24_1*)Pointer;
 
             public ref IntPtr Name => ref NativeParameter->name;
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/ParameterInfo/ParameterInfo_27_3.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/ParameterInfo/ParameterInfo_27_3.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace UnhollowerBaseLib.Runtime.VersionSpecific.ParameterInfo
+{
+    [ApplicableToUnityVersionsSince("2021.2.0")]
+    internal class NativeParameterInfoStructHandler_27_3 : INativeParameterInfoStructHandler
+    {
+        public unsafe Il2CppParameterInfo*[] CreateNewParameterInfoArray(int paramCount)
+        {
+            var ptr = (Il2CppParameterInfo_27_3*)Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppParameterInfo_27_3>() * paramCount);
+            var res = new Il2CppParameterInfo*[paramCount];
+            for (var i = 0; i < paramCount; i++)
+            {
+                ptr[i] = default;
+                res[i] = (Il2CppParameterInfo*)&ptr[i];
+            }
+            return res;
+        }
+
+        public unsafe INativeParameterInfoStruct Wrap(Il2CppParameterInfo* paramInfoPointer)
+        {
+            if ((IntPtr)paramInfoPointer == IntPtr.Zero) return null;
+            else return new NativeParameterInfoStructWrapper((IntPtr)paramInfoPointer);
+        }
+
+        public bool HasNamePosToken => false;
+
+#if DEBUG
+        public string GetName() => "NativeParameterInfoStructHandler_27_3";
+#endif
+
+        //Doesn't actually exist; just using this for type pointer storage in MethodInfo 27_3 +
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct Il2CppParameterInfo_27_3
+        {
+            public Il2CppTypeStruct* parameter_type;
+        }
+
+        internal unsafe class NativeParameterInfoStructWrapper : INativeParameterInfoStruct
+        {
+            public NativeParameterInfoStructWrapper(IntPtr pointer)
+            {
+                Pointer = pointer;
+            }
+
+            public IntPtr Pointer { get; }
+
+            public Il2CppParameterInfo* ParameterInfoPointer => (Il2CppParameterInfo*)Pointer;
+
+            public bool HasNamePosToken => false;
+
+            private Il2CppParameterInfo_27_3* NativeParameter => (Il2CppParameterInfo_27_3*)Pointer;
+
+            public ref IntPtr Name => throw new NotSupportedException("ParameterInfo does not exist in Unity 2021.2.0+");
+
+            public ref int Position => throw new NotSupportedException("ParameterInfo does not exist in Unity 2021.2.0+");
+
+            public ref uint Token => throw new NotSupportedException("ParameterInfo does not exist in Unity 2021.2.0+");
+
+            public ref Il2CppTypeStruct* ParameterType => ref NativeParameter->parameter_type;
+        }
+    }
+}


### PR DESCRIPTION
Due to some changes in the Il2Cpp headers, the version handling system needs extended to support Unity version `2021.2.0+`. I have dubbed this version `27_3`.
* ParameterInfo was removed
* MethodInfo now holds a type pointer array instead a parameter info array
* Class had some small changes in the bit fields

As such, I've tried to handle the ParameterInfo removal as elegantly as possible:
* I added a `HasNamePosToken` property to `UnityVersionHandler` and the interfaces for parameter info wrapping and handling
* I created a handler for ParameterInfo 27_3 with not supported exceptions for `Name`, `Position`, and `Token`
* In the handler, I created a false native struct containing only one member, `Il2CppTypeStruct* parameter_type`

This way ensures that code surrounding parameters remains clean, requiring only minimal changes like the ones implemented in `ClassInjector`.