### PR TITLE
add operator+ and operator- to MulticastDelegate types

### DIFF
--- a/AssemblyUnhollower/Passes/Pass60AddImplicitConversions.cs
+++ b/AssemblyUnhollower/Passes/Pass60AddImplicitConversions.cs
@@ -131,6 +131,33 @@ namespace AssemblyUnhollower.Passes
                     var convertMethodRef = new GenericInstanceMethod(genericConvertRef) { GenericArguments = { typeContext.SelfSubstitutedRef }};
                     bodyBuilder.Emit(OpCodes.Call, typeContext.NewType.Module.ImportReference(convertMethodRef));
                     bodyBuilder.Emit(OpCodes.Ret);
+
+                    // public static T operator+(T lhs, T rhs) => Il2CppSystem.Delegate.Combine(lhs, rhs).Cast<T>();
+                    var addMethod = new MethodDefinition("op_Addition", MethodAttributes.Static | MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig, typeContext.NewType);
+                    typeContext.NewType.Methods.Add(addMethod);
+                    addMethod.Parameters.Add(new ParameterDefinition(typeContext.NewType));
+                    addMethod.Parameters.Add(new ParameterDefinition(typeContext.NewType));
+                    var addBody = addMethod.Body.GetILProcessor();
+                    addBody.Emit(OpCodes.Ldarg_0);
+                    addBody.Emit(OpCodes.Ldarg_1);
+                    addBody.Emit(OpCodes.Call, assemblyContext.Imports.DelegateCombine);
+                    addBody.Emit(OpCodes.Call, assemblyContext.Imports.Module.ImportReference(new GenericInstanceMethod(assemblyContext.Imports.Il2CppObjectCast) { GenericArguments = { typeContext.NewType }}));
+                    addBody.Emit(OpCodes.Ret);
+
+                    // public static T operator-(T lhs, T rhs) => Il2CppSystem.Delegate.Remove(lhs, rhs)?.Cast<T>();
+                    var subtractMethod = new MethodDefinition("op_Subtraction", MethodAttributes.Static | MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig, typeContext.NewType);
+                    typeContext.NewType.Methods.Add(subtractMethod);
+                    subtractMethod.Parameters.Add(new ParameterDefinition(typeContext.NewType));
+                    subtractMethod.Parameters.Add(new ParameterDefinition(typeContext.NewType));
+                    var subtractBody = subtractMethod.Body.GetILProcessor();
+                    subtractBody.Emit(OpCodes.Ldarg_0);
+                    subtractBody.Emit(OpCodes.Ldarg_1);
+                    subtractBody.Emit(OpCodes.Call, assemblyContext.Imports.DelegateRemove);
+                    subtractBody.Emit(OpCodes.Dup);
+                    var ret = subtractBody.Create(OpCodes.Ret);
+                    subtractBody.Emit(OpCodes.Brfalse_S, ret);
+                    subtractBody.Emit(OpCodes.Call, assemblyContext.Imports.Module.ImportReference(new GenericInstanceMethod(assemblyContext.Imports.Il2CppObjectCast) { GenericArguments = { typeContext.NewType }}));
+                    subtractBody.Append(ret);
                 }
             }
         }


### PR DESCRIPTION
This allows simplifying code like this:
```cs
SceneManager.sceneLoaded = (
    (SceneManager.sceneLoaded == null)
    ? new Action<Scene, LoadSceneMode>(OnSceneLoad)
    : Il2CppSystem.Delegate.Combine(SceneManager.sceneLoaded, (UnityAction<Scene, LoadSceneMode>)new Action<Scene, LoadSceneMode>(OnSceneLoad)).Cast<UnityAction<Scene, LoadSceneMode>>()
    );
```
or:
```cs
SceneManager.sceneLoaded = Il2CppSystem.Delegate.Combine(SceneManager.sceneLoaded, new UnityAction<Scene, LoadSceneMode>(SceneManager.SceneLoaded)).Cast<UnityAction<Scene, LoadSceneMode>>();
```
into this:
```cs
SceneManager.sceneLoaded += new Action<Scene, LoadSceneMode>(OnSceneLoad);
```

Sadly C# was made by monkeys which can't draw a line between standard library and compiler so these operators don't exist by default.
The language specification asks us to null-check parameters but luckily that's exactly what Delegate.Combine and Delegate.Remove do too.