### PR TITLE
AssemblyUnhollower deobfuscation map generation | Fix for MissingKeyException and Type comparison

### DIFF
--- a/AssemblyUnhollower/AssemblyKnownImports.cs
+++ b/AssemblyUnhollower/AssemblyKnownImports.cs
@@ -42,6 +42,7 @@ namespace AssemblyUnhollower
         private readonly Lazy<TypeReference> myIl2CppArrayBase;
         private readonly Lazy<TypeReference> myIl2CppArrayBaseSetlfSubst;
         private readonly Lazy<TypeReference> myDefaultMemberAttribute;
+        private readonly Lazy<TypeReference> myIl2CppObjectReference;
 
         public TypeReference Void => myVoidReference.Value;
         public TypeReference IntPtr => myIntPtrReference.Value;
@@ -184,7 +185,7 @@ namespace AssemblyUnhollower
             myIl2CppArrayBaseSetlfSubst = new Lazy<TypeReference>(() => Module.ImportReference(new GenericInstanceType(Il2CppArrayBase) { GenericArguments = { Il2CppArrayBase.GenericParameters[0] }}));
             myIl2CppObjectBaseReference = new Lazy<TypeReference>(() => Module.ImportReference(typeof(Il2CppObjectBase)));
             myDefaultMemberAttribute = new Lazy<TypeReference>(() => Module.ImportReference(TargetTypeSystemHandler.DefaultMemberAttribute));
-            // myIl2CppObjectReference = new Lazy<TypeReference>(() => Module.ImportReference(TargetTypeSystemHandler.Object));// todo!
+            myIl2CppObjectReference = new Lazy<TypeReference>(() => Module.ImportReference(TargetTypeSystemHandler.Object));// todo!
             
             myIl2CppObjectToPointer = new Lazy<MethodReference>(() => Module.ImportReference(typeof(IL2CPP).GetMethod("Il2CppObjectBaseToPtr")));
             myIl2CppObjectToPointerNotNull = new Lazy<MethodReference>(() => Module.ImportReference(typeof(IL2CPP).GetMethod("Il2CppObjectBaseToPtrNotNull")));

--- a/AssemblyUnhollower/AssemblyKnownImports.cs
+++ b/AssemblyUnhollower/AssemblyKnownImports.cs
@@ -185,7 +185,7 @@ namespace AssemblyUnhollower
             myIl2CppArrayBaseSetlfSubst = new Lazy<TypeReference>(() => Module.ImportReference(new GenericInstanceType(Il2CppArrayBase) { GenericArguments = { Il2CppArrayBase.GenericParameters[0] }}));
             myIl2CppObjectBaseReference = new Lazy<TypeReference>(() => Module.ImportReference(typeof(Il2CppObjectBase)));
             myDefaultMemberAttribute = new Lazy<TypeReference>(() => Module.ImportReference(TargetTypeSystemHandler.DefaultMemberAttribute));
-            myIl2CppObjectReference = new Lazy<TypeReference>(() => Module.ImportReference(TargetTypeSystemHandler.Object));// todo!
+            myIl2CppObjectReference = new Lazy<TypeReference>(() => Module.ImportReference(TargetTypeSystemHandler.Object));
             
             myIl2CppObjectToPointer = new Lazy<MethodReference>(() => Module.ImportReference(typeof(IL2CPP).GetMethod("Il2CppObjectBaseToPtr")));
             myIl2CppObjectToPointerNotNull = new Lazy<MethodReference>(() => Module.ImportReference(typeof(IL2CPP).GetMethod("Il2CppObjectBaseToPtrNotNull")));

--- a/AssemblyUnhollower/Contexts/AssemblyRewriteContext.cs
+++ b/AssemblyUnhollower/Contexts/AssemblyRewriteContext.cs
@@ -7,7 +7,7 @@ namespace AssemblyUnhollower.Contexts
     public class AssemblyRewriteContext
     {
         public readonly RewriteGlobalContext GlobalContext;
-        
+
         public readonly AssemblyDefinition OriginalAssembly;
         public readonly AssemblyDefinition NewAssembly;
 
@@ -28,7 +28,21 @@ namespace AssemblyUnhollower.Contexts
             Imports = AssemblyKnownImports.For(newAssembly.MainModule, globalContext);
         }
 
-        public TypeRewriteContext GetContextForOriginalType(TypeDefinition type) => myOldTypeMap[type];
+        public TypeRewriteContext GetContextForOriginalType(TypeDefinition type)
+        {
+            try
+            {
+                return myOldTypeMap[type];
+            }
+            catch
+            {
+                foreach (var oldtype in myOldTypeMap.Keys)
+                {
+                    if (type.Name == oldtype.Name) return myOldTypeMap[oldtype];
+                }
+                return myNewTypeMap[type];
+            }
+        }
         public TypeRewriteContext? TryGetContextForOriginalType(TypeDefinition type) => myOldTypeMap.TryGetValue(type, out var result) ? result : null;
         public TypeRewriteContext GetContextForNewType(TypeDefinition type) => myNewTypeMap[type];
 
@@ -43,37 +57,38 @@ namespace AssemblyUnhollower.Contexts
         public MethodReference RewriteMethodRef(MethodReference methodRef)
         {
             var newType = GlobalContext.GetNewTypeForOriginal(methodRef.DeclaringType.Resolve());
-            return newType.GetMethodByOldMethod(methodRef.Resolve()).NewMethod; 
+            return newType.GetMethodByOldMethod(methodRef.Resolve()).NewMethod;
         }
-        
+
         public TypeReference RewriteTypeRef(TypeReference? typeRef)
         {
             if (typeRef == null) return Imports.Il2CppObjectBase;
-            
+
             var sourceModule = NewAssembly.MainModule;
 
             if (typeRef is ArrayType arrayType)
             {
                 if (arrayType.Rank != 1)
                     return Imports.Il2CppObjectBase;
-                
+
                 var elementType = arrayType.ElementType;
                 if (elementType.FullName == "System.String")
                     return Imports.Il2CppStringArray;
 
                 var convertedElementType = RewriteTypeRef(elementType);
                 if (elementType.IsGenericParameter)
-                    return new GenericInstanceType(Imports.Il2CppArrayBase) {GenericArguments = {convertedElementType}};
-                
+                    return new GenericInstanceType(Imports.Il2CppArrayBase) { GenericArguments = { convertedElementType } };
+
                 return new GenericInstanceType(convertedElementType.IsValueType
                     ? Imports.Il2CppStructArray
-                    : Imports.Il2CppReferenceArray) {GenericArguments = {convertedElementType}};
+                    : Imports.Il2CppReferenceArray)
+                { GenericArguments = { convertedElementType } };
             }
 
             if (typeRef is GenericParameter genericParameter)
             {
                 var genericParameterDeclaringType = genericParameter.DeclaringType;
-                if(genericParameterDeclaringType != null)
+                if (genericParameterDeclaringType != null)
                     return RewriteTypeRef(genericParameterDeclaringType).GenericParameters[genericParameter.Position];
 
                 return RewriteMethodRef(genericParameter.DeclaringMethod).GenericParameters[genericParameter.Position];
@@ -82,7 +97,7 @@ namespace AssemblyUnhollower.Contexts
             if (typeRef is ByReferenceType byRef)
                 return new ByReferenceType(RewriteTypeRef(byRef.ElementType));
 
-            if(typeRef is PointerType pointerType)
+            if (typeRef is PointerType pointerType)
                 return new PointerType(RewriteTypeRef(pointerType.ElementType));
 
             if (typeRef is GenericInstanceType genericInstance)
@@ -96,31 +111,48 @@ namespace AssemblyUnhollower.Contexts
 
             if (typeRef.IsPrimitive || typeRef.FullName == "System.TypedReference")
                 return sourceModule.ImportReference(TargetTypeSystemHandler.Object.Module.GetType(typeRef.Namespace, typeRef.Name));
-            
+
             if (typeRef.FullName == "System.Void")
                 return Imports.Void;
 
             if (typeRef.FullName == "System.String")
                 return Imports.String;
 
-            if(typeRef.FullName == "System.Object")
+            if (typeRef.FullName == "System.Object")
                 return sourceModule.ImportReference(GlobalContext.GetAssemblyByName("mscorlib").GetTypeByName("System.Object").NewType);
+
+            if (typeRef.FullName == "Il2CppSystem.Object")
+                return Imports.Object;
 
             if (typeRef.FullName == "System.Attribute")
                 return sourceModule.ImportReference(GlobalContext.GetAssemblyByName("mscorlib").GetTypeByName("System.Attribute").NewType);
 
-            var originalTypeDef = typeRef.Resolve();
+            TypeDefinition? originalTypeDef;
+            try
+            {
+                originalTypeDef = typeRef.Resolve();
+            }
+            catch
+            {
+                return Imports.Il2CppObjectBase;
+            }
             var targetAssembly = GlobalContext.GetNewAssemblyForOriginal(originalTypeDef.Module.Assembly);
-            var target = targetAssembly.GetContextForOriginalType(originalTypeDef).NewType;
+            var target = targetAssembly?.GetContextForOriginalType(originalTypeDef).NewType;
 
             return sourceModule.ImportReference(target);
         }
 
-        public TypeRewriteContext GetTypeByName(string name)
+        public TypeRewriteContext? GetTypeByName(string name)
         {
-            return myNameTypeMap[name];
+            return myNameTypeMap.TryGetValue(name, out var result1) ?
+                result1 :
+                myNameTypeMap.TryGetValue(name.Replace("System", "Il2CppSystem"), out var result2) ?
+                result2 :
+                myNameTypeMap.TryGetValue(name.Replace("Il2CppSystem", "System"), out var result3) ?
+                result3 :
+                null;
         }
-        
+
         public TypeRewriteContext? TryGetTypeByName(string name)
         {
             return myNameTypeMap.TryGetValue(name, out var result) ? result : null;

--- a/AssemblyUnhollower/Contexts/RewriteGlobalContext.cs
+++ b/AssemblyUnhollower/Contexts/RewriteGlobalContext.cs
@@ -12,10 +12,10 @@ namespace AssemblyUnhollower.Contexts
         public IIl2CppMetadataAccess GameAssemblies { get; }
         public IMetadataAccess SystemAssemblies { get; }
         public IMetadataAccess UnityAssemblies { get; }
-        
+
         private readonly Dictionary<string, AssemblyRewriteContext> myAssemblies = new Dictionary<string, AssemblyRewriteContext>();
         private readonly Dictionary<AssemblyDefinition, AssemblyRewriteContext> myAssembliesByOld = new Dictionary<AssemblyDefinition, AssemblyRewriteContext>();
-        
+
         internal readonly Dictionary<(object, string, int), List<TypeDefinition>> RenameGroups = new Dictionary<(object, string, int), List<TypeDefinition>>();
         internal readonly Dictionary<TypeDefinition, string> RenamedTypes = new Dictionary<TypeDefinition, string>();
         internal readonly Dictionary<TypeDefinition, string> PreviousRenamedTypes = new Dictionary<TypeDefinition, string>();
@@ -23,23 +23,23 @@ namespace AssemblyUnhollower.Contexts
         internal readonly List<long> MethodStartAddresses = new List<long>();
 
         public IEnumerable<AssemblyRewriteContext> Assemblies => myAssemblies.Values;
-        
+
         internal bool HasGcWbarrierFieldWrite { get; set; }
-        
+
         public RewriteGlobalContext(UnhollowerOptions options, IIl2CppMetadataAccess gameAssemblies, IMetadataAccess systemAssemblies, IMetadataAccess unityAssemblies)
         {
             Options = options;
             GameAssemblies = gameAssemblies;
             SystemAssemblies = systemAssemblies;
             UnityAssemblies = unityAssemblies;
-            
+
             TargetTypeSystemHandler.Init(systemAssemblies);
-            
+
             foreach (var sourceAssembly in gameAssemblies.Assemblies)
             {
                 var assemblyName = sourceAssembly.Name.Name;
                 if (assemblyName == "Il2CppDummyDll") continue;
-                
+
                 var newAssembly = AssemblyDefinition.CreateAssembly(
                     new AssemblyNameDefinition(sourceAssembly.Name.Name.UnSystemify(options), sourceAssembly.Name.Version),
                     sourceAssembly.MainModule.Name.UnSystemify(options), sourceAssembly.MainModule.Kind);
@@ -56,24 +56,42 @@ namespace AssemblyUnhollower.Contexts
                 myAssembliesByOld[context.OriginalAssembly] = context;
         }
 
-        public AssemblyRewriteContext GetNewAssemblyForOriginal(AssemblyDefinition oldAssembly)
+        public AssemblyRewriteContext? GetNewAssemblyForOriginal(AssemblyDefinition oldAssembly)
         {
-            return myAssembliesByOld[oldAssembly];
+            try
+            {
+                return myAssembliesByOld[oldAssembly];
+            }
+            catch
+            {
+                foreach (var assembly in myAssembliesByOld.Keys)
+                {
+                    if (assembly.Name == oldAssembly.Name)
+                        return myAssembliesByOld[assembly];
+                }
+                return myAssemblies.TryGetValue("Il2Cppmscorlib", out var result2) ? result2 : null;
+            }
         }
 
-        public TypeRewriteContext GetNewTypeForOriginal(TypeDefinition originalType)
+        public TypeRewriteContext? GetNewTypeForOriginal(TypeDefinition originalType)
         {
-            return GetNewAssemblyForOriginal(originalType.Module.Assembly)
-                .GetContextForOriginalType(originalType);
+            return (GetNewAssemblyForOriginal(originalType.Module.Assembly) ?? 
+                (myAssemblies.TryGetValue("Il2Cppmscorlib", out var result1) ? 
+                result1 : 
+                null))?
+                .GetContextForOriginalType(originalType) ?? 
+                (myAssemblies.TryGetValue("Il2Cppmscorlib", out var result2) ? 
+                result2.GetContextForOriginalType(originalType) : 
+                null);
         }
-        
+
         public TypeRewriteContext? TryGetNewTypeForOriginal(TypeDefinition originalType)
         {
             if (!myAssembliesByOld.TryGetValue(originalType.Module.Assembly, out var assembly))
                 return null;
             return assembly.TryGetContextForOriginalType(originalType);
         }
-        
+
         public TypeRewriteContext.TypeSpecifics JudgeSpecificsByOriginalType(TypeReference typeRef)
         {
             if (typeRef.IsPrimitive || typeRef.IsPointer || typeRef.FullName == "System.TypedReference") return TypeRewriteContext.TypeSpecifics.BlittableStruct;
@@ -81,14 +99,20 @@ namespace AssemblyUnhollower.Contexts
                 return TypeRewriteContext.TypeSpecifics.ReferenceType;
 
             var fieldTypeContext = GetNewTypeForOriginal(typeRef.Resolve());
-            return fieldTypeContext.ComputedTypeSpecifics;
+            return fieldTypeContext != null ? fieldTypeContext.ComputedTypeSpecifics : TypeRewriteContext.TypeSpecifics.NotComputed;
         }
 
-        public AssemblyRewriteContext GetAssemblyByName(string name)
+        public AssemblyRewriteContext? GetAssemblyByName(string name)
         {
-            return myAssemblies[name];
+            return myAssemblies.TryGetValue(name, out var result1) ?
+                result1 : 
+                myAssemblies.TryGetValue("mscorlib", out var result2) ? 
+                result2 : 
+                myAssemblies.TryGetValue("Il2Cppmscorlib", out var result3) ? 
+                result3 : 
+                null;
         }
-        
+
         public AssemblyRewriteContext? TryGetAssemblyByName(string name)
         {
             if (myAssemblies.TryGetValue(name, out var result))
@@ -96,7 +120,7 @@ namespace AssemblyUnhollower.Contexts
 
             if (name == "netstandard")
                 return myAssemblies.TryGetValue("mscorlib", out var result2) ? result2 : null;
-            
+
             return null;
         }
 

--- a/AssemblyUnhollower/DeobfuscationMapGenerator.cs
+++ b/AssemblyUnhollower/DeobfuscationMapGenerator.cs
@@ -109,14 +109,16 @@ namespace AssemblyUnhollower
 
                 void DoType(TypeRewriteContext typeContext, TypeRewriteContext? enclosingType)
                 {
-                    if (!typeContext.OriginalNameWasObfuscated) return;
+                    if(cleanAssembly.TryGetTypeByName(typeContext.NewType.Name) != null) return;
 
                     var cleanType = FindBestMatchType(typeContext, cleanAssembly, enclosingType);
                     if (cleanType.Item1 == null) return;
                     
-                    if (!usedNames.TryGetValue(cleanType.Item1.NewType, out var existing) || existing.Item2 < cleanType.Item2)
+                    if (!usedNames.TryGetValue(cleanType.Item1.NewType, out var existing) || existing.Penalty < cleanType.Item2)
                     {
-                        usedNames[cleanType.Item1.NewType] = (typeContext.NewType.GetNamespacePrefix() + "." + typeContext.NewType.Name, cleanType.Item2, typeContext.OriginalType.Namespace != cleanType.Item1.OriginalType.Namespace);
+                        string maybeWithDot = typeContext.NewType.GetNamespacePrefix() + ".";
+                        if (maybeWithDot.IndexOf('.') == 0) maybeWithDot = maybeWithDot.Substring(1);
+                        usedNames[cleanType.Item1.NewType] = (maybeWithDot + typeContext.NewType.Name, cleanType.Item2, typeContext.OriginalType.Namespace != cleanType.Item1.OriginalType.Namespace);
                     } else 
                         return;
 

--- a/AssemblyUnhollower/Passes/Pass11ComputeTypeSpecifics.cs
+++ b/AssemblyUnhollower/Passes/Pass11ComputeTypeSpecifics.cs
@@ -16,6 +16,7 @@ namespace AssemblyUnhollower.Passes
 
         private static void ComputeSpecifics(TypeRewriteContext typeContext)
         {
+            if (typeContext == null) return;
             if (typeContext.ComputedTypeSpecifics != TypeRewriteContext.TypeSpecifics.NotComputed) return;
             typeContext.ComputedTypeSpecifics = TypeRewriteContext.TypeSpecifics.Computing;
             
@@ -32,6 +33,7 @@ namespace AssemblyUnhollower.Passes
                 }
 
                 var fieldTypeContext = typeContext.AssemblyContext.GlobalContext.GetNewTypeForOriginal(fieldType.Resolve());
+                if (fieldTypeContext == null) return;
                 ComputeSpecifics(fieldTypeContext);
                 if (fieldTypeContext.ComputedTypeSpecifics != TypeRewriteContext.TypeSpecifics.BlittableStruct)
                 {

--- a/AssemblyUnhollower/Properties/launchSettings.json
+++ b/AssemblyUnhollower/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "AssemblyUnhollower": {
+      "commandName": "Project",
+      "commandLineArgs": "--input=\"D:\\House party\\modding\\deobf maps\\deobfuscated_no_regex\" --deobf-generate --deobf-generate-new=\"D:\\House party\\modding\\deobf maps\\obfuscated_no_regex\" --mscorlib=\"D:\\House party\\modding\\deobf maps\\deobfuscated\\mscorlib.dll\" --deobf-generate-asm=\"Assembly-CSharp\" --output=\"./House Party\""
+    }
+  }
+}

--- a/AssemblyUnhollower/Properties/launchSettings.json
+++ b/AssemblyUnhollower/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "AssemblyUnhollower": {
-      "commandName": "Project",
-      "commandLineArgs": "--input=\"D:\\House party\\modding\\deobf maps\\deobfuscated_no_regex\" --deobf-generate --deobf-generate-new=\"D:\\House party\\modding\\deobf maps\\obfuscated_no_regex\" --mscorlib=\"D:\\House party\\modding\\deobf maps\\deobfuscated\\mscorlib.dll\" --deobf-generate-asm=\"Assembly-CSharp\" --output=\"./House Party\""
-    }
-  }
-}


### PR DESCRIPTION
When trying to generate a map for House Party, I experienced the following error: 
`Unhandled Exception: System.Collections.Generic.KeyNotFoundException: The given key was not present in the dictionary.
   at System.ThrowHelper.ThrowKeyNotFoundException()
   at System.Collections.Generic.Dictionary'2.get_Item(TKey key)
   at AssemblyUnhollower.Contexts.RewriteGlobalContext.GetNewAssemblyForOriginal(AssemblyDefinition oldAssembly) in F:\Lenny\source\repos\Il2CppAssemblyUnhollower\AssemblyUnhollower\Contexts\RewriteGlobalContext.cs:line 61
   at AssemblyUnhollower.Contexts.AssemblyRewriteContext.RewriteTypeRef(TypeReference typeRef) in F:\Lenny\source\repos\Il2CppAssemblyUnhollower\AssemblyUnhollower\Contexts\AssemblyRewriteContext.cs:line 113
   at AssemblyUnhollower.Passes.Pass12FillTypedefs.DoPass(RewriteGlobalContext context) in F:\Lenny\source\repos\Il2CppAssemblyUnhollower\AssemblyUnhollower\Passes\Pass12FillTypedefs.cs:line 36
   at AssemblyUnhollower.DeobfuscationMapGenerator.GenerateDeobfuscationMap(UnhollowerOptions options) in F:\Lenny\source\repos\Il2CppAssemblyUnhollower\AssemblyUnhollower\DeobfuscationMapGenerator.cs:line 65
   at AssemblyUnhollower.Program.Main(String[] args) in F:\Lenny\source\repos\Il2CppAssemblyUnhollower\AssemblyUnhollower\Program.cs:line 168`

- I fixed this and a logic flaw(or a side effect of my fix, not sure) in the comparison as well so that maps are now generated correctly.
- Added more fallback if an assembly could not be found, at all times it was either mscorlib or Il2Cppmscorlib, so I added special cases.
- Removed the leading dot on missing empty namespaces so it looks more clean
- added handling for the `System.Object`

This shouldn't change anything about the main Unhollower functionality, only deobfuscation map generation.